### PR TITLE
Tidy up PHP code examples in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,14 +18,14 @@ That's it!
 PhockitoUnit in Action
 ============
 Here is a very classic PHP Unit test that uses Phockito to mock a dependency
-```
+```php
 class SomeTest extends PHPUnit_Framework_TestCase
 {
   public function setUp(){
     Phockito::include_hamcrest();
   }
   
-  testSomeMethod(){
+  function testSomeMethod(){
     /** @var SomeDependency $mockDependency **/
     $mockDependency = Phockito::mock('SomeDependency');
     Phockito::when($mockDependency->dependentMethod(anything()))->return("value");
@@ -35,7 +35,7 @@ class SomeTest extends PHPUnit_Framework_TestCase
     $this->assertEquals("value", $instance->methodThatUsesDependency());
   }
   
-  testSomeMethodWhenSomeDependencyThrows(){
+  function testSomeMethodWhenSomeDependencyThrows(){
     /** @var SomeDependency $mockDependency **/
     $mockDependency = Phockito::mock('SomeDependency');
     Phockito::when($mockDependency->dependentMethod(anything()))->throw(new Exception("Some error"));
@@ -52,15 +52,13 @@ class SomeTest extends PHPUnit_Framework_TestCase
 ```
 Certainly you have encoutnered or written a unit tests that is at least similar to this structure.  PhockitoUnit simplifies this structure by eliminating some common boilerplate, here it is:
 
-```
+```php
 class SomeTest extends \PhockitoUnit\PhockitoUnitTestCase
 {
-  
   /** @var SomeDependency **/
   protected $mockDependency;
   
-  testSomeMethod(){
-    
+  function testSomeMethod(){
     Phockito::when($this->mockDependency->dependentMethod(anything()))->return("value");
     
     $instance = new ThingThatNeedsDependency($mockDependency);
@@ -68,8 +66,7 @@ class SomeTest extends \PhockitoUnit\PhockitoUnitTestCase
     $this->assertEquals("value", $instance->methodThatUsesDependency());
   }
   
-  testSomeMethodWhenSomeDependencyThrows(){
-
+  function testSomeMethodWhenSomeDependencyThrows(){
     Phockito::when($this->mockDependency->dependentMethod(anything()))->throw(new Exception("Some error"));
     
     $instance = new ThingThatNeedsDependency($mockDependency);
@@ -83,10 +80,9 @@ class SomeTest extends \PhockitoUnit\PhockitoUnitTestCase
 }
 ```
 It's not a monsterous change, but it helps quite a bit, eliminating the chance of class name typos, class rename refactorings, etc.  And in more advanced scenarios where you are mocking an domain object graph it can make it easier to write more tests.  More tests means more coverage of intent.  Here's an example that sets up a graph and uses a spy:
-```
+```php
 class FamilyTest extends \PhockitoUnit\PhockitoUnitTestCase
 {
-  
   /** @var Child **/
   protected $mockChild1;
   
@@ -101,11 +97,9 @@ class FamilyTest extends \PhockitoUnit\PhockitoUnitTestCase
     
     Phockito::when($this->mockParent->getEledestChild())->return($this->mockChild1);
     Phockito::when($this->mockParent->getYoungestChild())->return($this->spyChild1);
-    
   }
   
-  testGetEldestChildNickName(){
-    
+  function testGetEldestChildNickName(){
     Phockito::when($this->mockChild1->getNickName())->return("Oldie");
     
     $family = new Family(array($this->mockParent));
@@ -113,14 +107,13 @@ class FamilyTest extends \PhockitoUnit\PhockitoUnitTestCase
     $this->assertEquals("Oldie", $family->getElestChildNickName());
   }
   
-  testGetYoungestchildFullName(){
-    
+  function testGetYoungestchildFullName(){
     Phockito::when($this->spyChild2->getFirstName())->return("Youngy");
     Phockito::when($this->spyChild2->getLastName())->return("McYoung");
     
     $family = new Family(array($this->mockParent));
     
-    $this->assertEquals("Youngy McYoung", $parent->testGetYoungestchildFullName());
+    $this->assertEquals("Youngy McYoung", $family->testGetYoungestchildFullName());
   }
 }
 ```


### PR DESCRIPTION
Hi,

Just spotted this library after considering writing something similar myself - looks neat! I haven't had a chance to try it out yet, but I'm looking forward to it.

I just noticed that the PHP code examples in the readme could do with a little love, and since it was so quick to do I thought I'd submit a PR right here and now.

Changes are fairly obvious, but to be explicit, I have:
- Added PHP syntax highlighting
- Added missing 'function' keywords
- Referenced $family instead of the undefined variable $parent (which I assume was the original intent?)
- Made the spacing consistent (no newlines at the start of classes or functions)

Thanks!
Rowan
